### PR TITLE
feat: timestamp determined on data pull instead of database insertion

### DIFF
--- a/integration/benthos/resources.yaml
+++ b/integration/benthos/resources.yaml
@@ -17,9 +17,9 @@ output_resources:
     sql_raw:
       driver: postgres
       dsn: postgres://${USER}:${PASSWORD}@${DATABASE_HOST}:5432/bead?sslmode=disable
-      query: INSERT INTO taxi_availability (batch_id, location) VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326));
+      query: INSERT INTO taxi_availability (batch_id, created_at, location) VALUES ($1, $2, ST_SetSRID(ST_MakePoint($3, $4), 4326));
       args_mapping: |
-        root = [ this.b_id, this.lon, this.lat ]
+        root = [ this.b_id, this.created_at, this.lon, this.lat ]
       batching:
         count: 500
         period: 1s

--- a/integration/python/script_server.py
+++ b/integration/python/script_server.py
@@ -3,6 +3,7 @@ from flask import Flask
 import requests
 import os
 import uuid
+import datetime
 
 API_URL = "http://datamall2.mytransport.sg/ltaodataservice/Taxi-Availability"
 SKIP_CONST = 500
@@ -22,11 +23,13 @@ def get_taxis():
     all_results = []
 
     batch_id = uuid.uuid4()
+    created_at = datetime.datetime.now().isoformat()
 
     def mapper(e):
         e['lat'] = e.pop('Latitude', None)
         e['lon'] = e.pop('Longitude', None)
-        e["b_id"] = batch_id
+        e['b_id'] = batch_id
+        e['created_at'] = created_at
         return e
 
     while more and counter < QUERY_LIMIT:


### PR DESCRIPTION
Timestamps determined when data is pulled instead of being set by the database to ensure each batch has the same `created_at` value.